### PR TITLE
Compatibility with HammersAndSmithing and Frycmod

### DIFF
--- a/src/main/java/com/glisco/numismaticoverhaul/villagers/data/VillagerTradesResourceListener.java
+++ b/src/main/java/com/glisco/numismaticoverhaul/villagers/data/VillagerTradesResourceListener.java
@@ -7,6 +7,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.resource.JsonDataLoader;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
@@ -17,6 +18,7 @@ import net.minecraft.village.VillagerProfession;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class VillagerTradesResourceListener extends JsonDataLoader implements IdentifiableResourceReloadListener {
 
@@ -39,7 +41,7 @@ public class VillagerTradesResourceListener extends JsonDataLoader implements Id
         loader.forEach((identifier, jsonElement) -> {
             if (!jsonElement.isJsonObject()) return;
             JsonObject root = jsonElement.getAsJsonObject();
-            VillagerTradesHandler.loadProfession(identifier, root);
+            if(!HammersAndTablesCompat(root)) VillagerTradesHandler.loadProfession(identifier, root);
         });
 
         NumismaticVillagerTradesRegistry.wrapModVillagers();
@@ -52,5 +54,14 @@ public class VillagerTradesResourceListener extends JsonDataLoader implements Id
             TradeOffers.WANDERING_TRADER_TRADES.putAll(registry.getRight());
         }
 
+    }
+
+    //Trade offers from json files for armorer, toolsmith and weaponsmith are disabled when Hammers and Smithing or Frycmod is installed
+    public boolean HammersAndTablesCompat(JsonObject root){
+        if(!FabricLoader.getInstance().isModLoaded("hammersandtables") && !FabricLoader.getInstance().isModLoaded("frycmod")) return false;
+
+        return Objects.equals(root.get("profession").getAsString(), "armorer") ||
+                Objects.equals(root.get("profession").getAsString(), "toolsmith") ||
+                Objects.equals(root.get("profession").getAsString(), "weaponsmith");
     }
 }

--- a/src/main/java/com/glisco/numismaticoverhaul/villagers/data/VillagerTradesResourceListener.java
+++ b/src/main/java/com/glisco/numismaticoverhaul/villagers/data/VillagerTradesResourceListener.java
@@ -58,10 +58,17 @@ public class VillagerTradesResourceListener extends JsonDataLoader implements Id
 
     //Trade offers from json files for armorer, toolsmith and weaponsmith are disabled when Hammers and Smithing or Frycmod is installed
     public boolean HammersAndTablesCompat(Identifier file){
-        if(!FabricLoader.getInstance().isModLoaded("hammersandtables") && !FabricLoader.getInstance().isModLoaded("frycmod")) return false;
-
-        return Objects.equals(file.toString(), "numismatic-overhaul:armorer") ||
-                Objects.equals(file.toString(), "numismatic-overhaul:toolsmith") ||
-                Objects.equals(file.toString(), "numismatic-overhaul:weaponsmith");
+        if(FabricLoader.getInstance().isModLoaded("hammersandtables")){
+            return Objects.equals(file.toString(), "numismatic-overhaul:armorer") ||
+                    Objects.equals(file.toString(), "numismatic-overhaul:toolsmith") ||
+                    Objects.equals(file.toString(), "numismatic-overhaul:weaponsmith");
+        }
+        else if(FabricLoader.getInstance().isModLoaded("frycmod")){
+            return Objects.equals(file.toString(), "numismatic-overhaul:armorer") ||
+                    Objects.equals(file.toString(), "numismatic-overhaul:toolsmith") ||
+                    Objects.equals(file.toString(), "numismatic-overhaul:weaponsmith") ||
+                    Objects.equals(file.toString(), "numismatic-overhaul:librarian");
+        }
+        return false;
     }
 }

--- a/src/main/java/com/glisco/numismaticoverhaul/villagers/data/VillagerTradesResourceListener.java
+++ b/src/main/java/com/glisco/numismaticoverhaul/villagers/data/VillagerTradesResourceListener.java
@@ -41,7 +41,7 @@ public class VillagerTradesResourceListener extends JsonDataLoader implements Id
         loader.forEach((identifier, jsonElement) -> {
             if (!jsonElement.isJsonObject()) return;
             JsonObject root = jsonElement.getAsJsonObject();
-            if(!HammersAndTablesCompat(root)) VillagerTradesHandler.loadProfession(identifier, root);
+            if(!HammersAndTablesCompat(identifier)) VillagerTradesHandler.loadProfession(identifier, root);
         });
 
         NumismaticVillagerTradesRegistry.wrapModVillagers();
@@ -57,11 +57,11 @@ public class VillagerTradesResourceListener extends JsonDataLoader implements Id
     }
 
     //Trade offers from json files for armorer, toolsmith and weaponsmith are disabled when Hammers and Smithing or Frycmod is installed
-    public boolean HammersAndTablesCompat(JsonObject root){
+    public boolean HammersAndTablesCompat(Identifier file){
         if(!FabricLoader.getInstance().isModLoaded("hammersandtables") && !FabricLoader.getInstance().isModLoaded("frycmod")) return false;
 
-        return Objects.equals(root.get("profession").getAsString(), "armorer") ||
-                Objects.equals(root.get("profession").getAsString(), "toolsmith") ||
-                Objects.equals(root.get("profession").getAsString(), "weaponsmith");
+        return Objects.equals(file.toString(), "numismatic-overhaul:armorer") ||
+                Objects.equals(file.toString(), "numismatic-overhaul:toolsmith") ||
+                Objects.equals(file.toString(), "numismatic-overhaul:weaponsmith");
     }
 }


### PR DESCRIPTION
This will let my mods change trade offers for armorer, toolsmith and weaponsmith.

Hammers and Smithing (and Frycmod) overwrites some vanilla trade offers and these changes disappear when Numismatic Overhaul is installed