### PR TITLE
Backport fixes for 1.20.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ version = "${project.mod_version}+${project.minecraft_base_version}"
 group = project.maven_group
 
 repositories {
-    maven   { url "https://maven.terraformersmc.com/" }
+    maven   { url = "https://maven.terraformersmc.com/" }
     maven   { url = "https://maven.ladysnake.org/releases" }
     maven   { url = "https://maven.shedaniel.me/" }
     maven   { url = "https://maven.wispforest.io/" }
@@ -39,7 +39,7 @@ dependencies {
     }
 
     // Stacc
-    modLocalRuntime include("net.devtech:stacc:${project.stacc_version}") {
+    modLocalRuntime include("maven.modrinth:stacc-api:${project.stacc_version}") {
         exclude(group: "net.fabricmc.fabric-api")
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 //file:noinspection GradlePackageVersionRange
 plugins {
-    id 'fabric-loom' version '1.1-SNAPSHOT'
+    id 'fabric-loom' version '1.4-SNAPSHOT'
     id 'maven-publish'
     id 'io.github.juuxel.loom-quiltflower' version '1.7.3'
 }
@@ -28,19 +28,34 @@ dependencies {
     modImplementation include("dev.onyxstudios.cardinal-components-api:cardinal-components-entity:${project.cca_version}")
 
     // REI
-    modCompileOnly "me.shedaniel:RoughlyEnoughItems-api-fabric:${project.rei_version}"
-    modLocalRuntime "me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}"
-    modLocalRuntime "dev.architectury:architectury-fabric:8.1.73"
+    modCompileOnly("me.shedaniel:RoughlyEnoughItems-api-fabric:${project.rei_version}") {
+        exclude(group: "net.fabricmc.fabric-api")
+    }
+    modLocalRuntime ("me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}") {
+        exclude(group: "net.fabricmc.fabric-api")
+    }
+    modLocalRuntime ("dev.architectury:architectury-fabric:8.1.73") {
+        exclude(group: "net.fabricmc.fabric-api")
+    }
 
     // Stacc
-    modLocalRuntime include("net.devtech:stacc:${project.stacc_version}")
+    modLocalRuntime include("net.devtech:stacc:${project.stacc_version}") {
+        exclude(group: "net.fabricmc.fabric-api")
+    }
 
     // ModMenu
-    modImplementation "com.terraformersmc:modmenu:${project.modmenu_version}"
+    modImplementation ("com.terraformersmc:modmenu:${project.modmenu_version}") {
+        exclude(group: "net.fabricmc.fabric-api")
+    }
 
     // oωo
-    modImplementation annotationProcessor("io.wispforest:owo-lib:${project.owo_version}")
-    modCompileOnly include("io.wispforest:owo-sentinel:${project.owo_version}")
+    modImplementation annotationProcessor("io.wispforest:owo-lib:${project.owo_version}") {
+        exclude(group: "net.fabricmc.fabric-api")
+    }
+
+    modCompileOnly include("io.wispforest:owo-sentinel:${project.owo_version}") {
+        exclude(group: "net.fabricmc.fabric-api")
+    }
 }
 
 base {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,10 +6,10 @@ org.gradle.jvmargs=-Xmx1G
     minecraft_base_version=1.20.1
     minecraft_version=1.20.1
     yarn_mappings=1.20.1+build.9
-    loader_version=0.14.25
+    loader_version=0.15.3
 
 # Mod Properties
-    mod_version=0.2.11
+    mod_version=0.2.12
     maven_group=com.glisco
     archives_base_name=numismatic-overhaul
 
@@ -30,4 +30,4 @@ org.gradle.jvmargs=-Xmx1G
     modmenu_version=7.2.2
 
     # https://storage.googleapis.com/devan-maven/
-    stacc_version=1.5.3-pre.1
+    stacc_version=1.7.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.jvmargs=-Xmx1G
     loader_version=0.14.21
 
 # Mod Properties
-    mod_version=0.2.10
+    mod_version=0.2.11
     maven_group=com.glisco
     archives_base_name=numismatic-overhaul
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-    minecraft_base_version=1.20
-    minecraft_version=1.20
-    yarn_mappings=1.20+build.1
-    loader_version=0.14.21
+    minecraft_base_version=1.20.1
+    minecraft_version=1.20.1
+    yarn_mappings=1.20.1+build.9
+    loader_version=0.14.25
 
 # Mod Properties
     mod_version=0.2.11
@@ -15,7 +15,7 @@ org.gradle.jvmargs=-Xmx1G
 
 # Dependencies
 # check this on https://fabricmc.net/develop
-    fabric_version=0.83.0+1.20
+    fabric_version=0.91.0+1.20.1
 
     # https://github.com/OnyxStudios/Cardinal-Components-API/releases
     cca_version=5.2.1
@@ -24,10 +24,10 @@ org.gradle.jvmargs=-Xmx1G
     rei_version=12.0.622
 
     # https://maven.wispforest.io/io/wispforest/owo-lib/
-    owo_version=0.11.0+1.20
+    owo_version=0.11.2+1.20
 
-    # https://www.curseforge.com/minecraft/mc-mods/modmenu/files
-    modmenu_version=7.0.0
+    # https://modrinth.com/mod/modmenu
+    modmenu_version=7.2.2
 
     # https://storage.googleapis.com/devan-maven/
     stacc_version=1.5.3-pre.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/glisco/numismaticoverhaul/NumismaticOverhaulConfigModel.java
+++ b/src/main/java/com/glisco/numismaticoverhaul/NumismaticOverhaulConfigModel.java
@@ -17,25 +17,26 @@ public class NumismaticOverhaulConfigModel {
     @Comment("Whether Numismatic currency should be injected into the loot tables of loot chests")
     public boolean generateCurrencyInChests = true;
 
-    @Comment("Where the purse in your inventory should be placed on the X axis")
-    public int pursePositionX = 27;
-
-    @Comment("Where the purse in your inventory should be placed on the Y axis")
-    public int pursePositionY = -28;
-
-    @Comment("Where the purse in your inventory should be placed on the X axis")
-    public int pursePositionCreativeX = 38;
-
-    @Comment("Where the purse in your inventory should be placed on the Y axis")
-    public int pursePositionCreativeY = 4;
-
     @Comment("Where the notification for adding/removing money from the purse should be (requires rejoining to apply)")
     @Sync(Option.SyncMode.INFORM_SERVER)
     public MoneyMessageLocation moneyMessageLocation = MoneyMessageLocation.ACTIONBAR;
 
     @Nest
-    public LootOptions lootOptions = new LootOptions();
+    public PurseOffsets purseOffsets = new PurseOffsets();
 
+    public static class PurseOffsets {
+        public int survivalX = 0;
+        public int survivalY = 0;
+
+        public int creativeX = 0;
+        public int creativeY = 0;
+
+        public int merchantX = 0;
+        public int merchantY = 0;
+    }
+
+    @Nest
+    public LootOptions lootOptions = new LootOptions();
 
     public static class LootOptions {
         @Comment("Affects money gained from Desert Temple chests")

--- a/src/main/java/com/glisco/numismaticoverhaul/block/ShopBlock.java
+++ b/src/main/java/com/glisco/numismaticoverhaul/block/ShopBlock.java
@@ -97,6 +97,8 @@ public class ShopBlock extends BlockWithEntity {
     public void onStateReplaced(BlockState state, World world, BlockPos pos, BlockState newState, boolean moved) {
         if (state.getBlock() != newState.getBlock()) {
             if (world.getBlockEntity(pos) instanceof ShopBlockEntity shop) {
+                shop.getMerchant().setCustomer(null);
+
                 CurrencyConverter.getAsValidStacks(shop.getStoredCurrency())
                         .forEach(stack -> ItemScatterer.spawn(shop.getWorld(), pos.getX(), pos.getY(), pos.getZ(), stack));
 

--- a/src/main/java/com/glisco/numismaticoverhaul/block/ShopBlockEntity.java
+++ b/src/main/java/com/glisco/numismaticoverhaul/block/ShopBlockEntity.java
@@ -39,6 +39,7 @@ public class ShopBlockEntity extends LockableContainerBlockEntity implements Imp
 
     private final DefaultedList<ItemStack> INVENTORY = DefaultedList.ofSize(27, ItemStack.EMPTY);
 
+    public boolean busy = false;
     private final Merchant merchant;
     private final List<ShopOffer> offers;
 

--- a/src/main/java/com/glisco/numismaticoverhaul/block/ShopMerchant.java
+++ b/src/main/java/com/glisco/numismaticoverhaul/block/ShopMerchant.java
@@ -34,6 +34,7 @@ public class ShopMerchant implements Merchant {
     @Override
     public void setCustomer(@Nullable PlayerEntity customer) {
         this.customer = customer;
+        this.shop.busy = customer != null;
     }
 
     @Nullable

--- a/src/main/java/com/glisco/numismaticoverhaul/block/ShopScreenHandler.java
+++ b/src/main/java/com/glisco/numismaticoverhaul/block/ShopScreenHandler.java
@@ -31,7 +31,6 @@ public class ShopScreenHandler extends ScreenHandler {
 
     private final List<ShopOffer> offers;
 
-    @Environment(EnvType.SERVER)
     private ShopBlockEntity shop = null;
 
     public ShopScreenHandler(int syncId, PlayerInventory playerInventory) {

--- a/src/main/java/com/glisco/numismaticoverhaul/block/ShopScreenHandler.java
+++ b/src/main/java/com/glisco/numismaticoverhaul/block/ShopScreenHandler.java
@@ -62,9 +62,6 @@ public class ShopScreenHandler extends ScreenHandler {
                 screen.afterDataUpdate();
             }
         });
-//
-//        Trade Buffer Slot
-//        this.bufferInventory.addListener(this::onBufferChanged);
     }
 
     @Override
@@ -144,6 +141,12 @@ public class ShopScreenHandler extends ScreenHandler {
     @Override
     public ItemStack quickMove(PlayerEntity player, int invSlot) {
         return ScreenUtils.handleSlotTransfer(this, invSlot, this.shopInventory.size());
+    }
+
+    @Override
+    public void onClosed(PlayerEntity player) {
+        super.onClosed(player);
+        this.shop.busy = false;
     }
 
     private static class AutoHidingSlot extends Slot {

--- a/src/main/java/com/glisco/numismaticoverhaul/block/ShopScreenHandler.java
+++ b/src/main/java/com/glisco/numismaticoverhaul/block/ShopScreenHandler.java
@@ -146,7 +146,7 @@ public class ShopScreenHandler extends ScreenHandler {
     @Override
     public void onClosed(PlayerEntity player) {
         super.onClosed(player);
-        this.shop.busy = false;
+        if (this.shop != null) this.shop.busy = false;
     }
 
     private static class AutoHidingSlot extends Slot {

--- a/src/main/java/com/glisco/numismaticoverhaul/client/NumismaticOverhaulClient.java
+++ b/src/main/java/com/glisco/numismaticoverhaul/client/NumismaticOverhaulClient.java
@@ -24,7 +24,6 @@ import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
 import net.minecraft.client.gui.screen.ingame.HandledScreens;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
 import net.minecraft.client.gui.screen.ingame.MerchantScreen;
-import net.minecraft.client.gui.widget.TexturedButtonWidget;
 import net.minecraft.client.item.ModelPredicateProviderRegistry;
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactories;
 import net.minecraft.util.Identifier;
@@ -62,13 +61,13 @@ public class NumismaticOverhaulClient implements ClientModInitializer {
 
         Layers.add(
                 PurseLayerContainer::new,
-                new PurseLayerElement<>((instance, component, xOffset, yOffset) -> {
+                new PurseLayerElement<>((instance, component) -> {
                     instance.aggressivePositioning = true;
                     ((LayerInstanceAccessor) instance).numismatic$getLayoutUpdaters().add(() -> {
                         if (instance.screen.isInventoryTabSelected()) {
                             component.positioning(Positioning.absolute(
-                                    ((HandledScreenAccessor) instance.screen).owo$getRootX() + NumismaticOverhaul.CONFIG.pursePositionCreativeX(),
-                                    ((HandledScreenAccessor) instance.screen).owo$getRootY() + NumismaticOverhaul.CONFIG.pursePositionCreativeY()
+                                    ((HandledScreenAccessor) instance.screen).owo$getRootX() + 38 + NumismaticOverhaul.CONFIG.purseOffsets.creativeX() ,
+                                    ((HandledScreenAccessor) instance.screen).owo$getRootY() + 4 + NumismaticOverhaul.CONFIG.purseOffsets.creativeY()
                             ));
                         } else {
                             component.positioning(Positioning.absolute(-50, -50));
@@ -80,24 +79,24 @@ public class NumismaticOverhaulClient implements ClientModInitializer {
 
         Layers.add(
                 PurseLayerContainer::new,
-                new PurseLayerElement<>((instance, component, xOffset, yOffset) -> {
+                new PurseLayerElement<>((instance, component) -> {
                     instance.aggressivePositioning = true;
-                    ((LayerInstanceAccessor) instance).numismatic$getLayoutUpdaters().add(() -> {
-                        var recipeBookButton = instance.queryWidget($ -> $ instanceof TexturedButtonWidget);
-                        if (recipeBookButton == null) return;
-
-                        component.positioning(
-                                Positioning.absolute(recipeBookButton.getX() + xOffset + NumismaticOverhaul.CONFIG.pursePositionX(),
-                                        recipeBookButton.getY() + yOffset + NumismaticOverhaul.CONFIG.pursePositionY())
-                        );
-                    });
+                    instance.alignComponentToHandledScreenCoordinates(
+                            component,
+                            160 + NumismaticOverhaul.CONFIG.purseOffsets.survivalX(),
+                            5 + NumismaticOverhaul.CONFIG.purseOffsets.survivalY()
+                    );
                 }),
                 InventoryScreen.class
         );
 
         Layers.add(
                 PurseLayerContainer::new,
-                new PurseLayerElement<>((instance, component, xOffset, yOffset) -> instance.alignComponentToHandledScreenCoordinates(component, 232 + xOffset, 33 + yOffset)),
+                new PurseLayerElement<>((instance, component) -> instance.alignComponentToHandledScreenCoordinates(
+                        component,
+                        260 + NumismaticOverhaul.CONFIG.purseOffsets.merchantX(),
+                        5 + NumismaticOverhaul.CONFIG.purseOffsets.merchantY()
+                )),
                 MerchantScreen.class
         );
     }

--- a/src/main/java/com/glisco/numismaticoverhaul/client/gui/PurseLayerElement.java
+++ b/src/main/java/com/glisco/numismaticoverhaul/client/gui/PurseLayerElement.java
@@ -39,11 +39,8 @@ public class PurseLayerElement<S extends Screen> implements Consumer<Layer<S, St
     @Override
     @SuppressWarnings("DataFlowIssue")
     public void accept(Layer<S, StackLayout>.Instance instance) {
-        int x = NumismaticOverhaul.CONFIG.pursePositionX();
-        int y = NumismaticOverhaul.CONFIG.pursePositionY();
-
         var popup = UIModelLoader.get(NumismaticOverhaul.id("purse")).expandTemplate(StackLayout.class, "popup", Map.of());
-        this.alignmentFunction.align(instance, popup, x - 30, y + 15);
+        this.alignmentFunction.align(instance, popup);
 
         var total = new MutableObject<LongSupplier>();
         var goldCount = configureSelector(
@@ -86,7 +83,7 @@ public class PurseLayerElement<S extends Screen> implements Consumer<Layer<S, St
 
         var button = UIModelLoader.get(NumismaticOverhaul.id("purse")).expandTemplate(ButtonComponent.class, "button", Map.of());
         instance.adapter.rootComponent.child(button);
-        this.alignmentFunction.align(instance, button, x, y);
+        this.alignmentFunction.align(instance, button);
 
         button.onPress(buttonComponent -> {
             if (Screen.hasShiftDown()) {
@@ -128,6 +125,6 @@ public class PurseLayerElement<S extends Screen> implements Consumer<Layer<S, St
 
     @FunctionalInterface
     public interface AlignmentFunction<S extends Screen> {
-        void align(Layer<S, StackLayout>.Instance instance, Component component, int xOffset, int yOffset);
+        void align(Layer<S, StackLayout>.Instance instance, Component component);
     }
 }

--- a/src/main/resources/assets/numismatic-overhaul/lang/en_us.json
+++ b/src/main/resources/assets/numismatic-overhaul/lang/en_us.json
@@ -42,11 +42,14 @@
   "text.config.numismatic-overhaul.title": "Numismatic Overhaul Configuration",
   "text.config.numismatic-overhaul.option.enableVillagerTrading": "Enable Villager Trading",
   "text.config.numismatic-overhaul.option.enableMcaCompatibility": "Enable MCA Compatibility",
-  "text.config.numismatic-overhaul.option.pursePositionX": "Purse X Coordinate",
-  "text.config.numismatic-overhaul.option.pursePositionY": "Purse Y Coordinate",
-  "text.config.numismatic-overhaul.option.pursePositionCreativeX": "Creative Purse X Coordinate",
-  "text.config.numismatic-overhaul.option.pursePositionCreativeY": "Creative Purse Y Coordinate",
-  "text.config.numismatic-overhaul.option.generateCurrencyInChests": "Generate currency in loot chests",
+
+  "text.config.numismatic-overhaul.category.purseOffsets": "Purse offsets",
+  "text.config.numismatic-overhaul.option.purseOffsets.survivalX": "Survival - X",
+  "text.config.numismatic-overhaul.option.purseOffsets.survivalY": "Survival - Y",
+  "text.config.numismatic-overhaul.option.purseOffsets.creativeX": "Creative - X",
+  "text.config.numismatic-overhaul.option.purseOffsets.creativeY": "Creative - Y",
+  "text.config.numismatic-overhaul.option.purseOffsets.merchantX": "Merchants - X",
+  "text.config.numismatic-overhaul.option.purseOffsets.merchantY": "Merchants - Y",
 
   "text.config.numismatic-overhaul.category.lootOptions": "Loot Generation",
   "text.config.numismatic-overhaul.option.lootOptions.desertMinLoot": "Desert Temple Minimum Loot",
@@ -58,6 +61,7 @@
   "text.config.numismatic-overhaul.option.lootOptions.strongholdLibraryMinLoot": "Stronghold Library Minimum Loot",
   "text.config.numismatic-overhaul.option.lootOptions.strongholdLibraryMaxLoot": "Stronghold Library Maximum Loot",
 
+  "text.config.numismatic-overhaul.option.generateCurrencyInChests": "Generate currency in loot chests",
   "text.config.numismatic-overhaul.option.moneyMessageLocation": "Money Message Location",
   "text.config.numismatic-overhaul.option.moneyMessageLocation.tooltip": "Decides where the money notification appears (requires rejoining world to apply)",
   "text.config.numismatic-overhaul.enum.moneyMessageLocation.actionbar": "Actionbar",

--- a/src/main/resources/assets/numismatic-overhaul/owo_ui/purse.xml
+++ b/src/main/resources/assets/numismatic-overhaul/owo_ui/purse.xml
@@ -90,6 +90,11 @@
                         </renderer>
                     </button>
                 </children>
+
+                <margins>
+                    <left>-30</left>
+                    <top>15</top>
+                </margins>
             </stack-layout>
         </template>
 


### PR DESCRIPTION
- Update Stacc to latest version (1.7.0)
- Fix issues related to multiple players accessing a shop at the same time (#116)
- Backport a fix for the crash with latest Fabric Loader (#117, already fixed for 1.20.2)
- Improve purse offsets on different screens, as well as their configurability
- Fix spacing with the coin/money bag tooltips (#108)

shoutouts to glisco for fixing the major issues here, like dupe, configurability, and tooltips