### PR TITLE
[1.20.1] Added Buy_Tag Handler to Villager Trade Data

### DIFF
--- a/src/main/java/com/glisco/numismaticoverhaul/villagers/json/VillagerTradesHandler.java
+++ b/src/main/java/com/glisco/numismaticoverhaul/villagers/json/VillagerTradesHandler.java
@@ -55,6 +55,7 @@ public class VillagerTradesHandler {
         tradeTypesRegistry.put(NumismaticOverhaul.id("sell_potion_container"), new SellPotionContainerItemAdapter());
         tradeTypesRegistry.put(NumismaticOverhaul.id("buy_item"), new BuyStackAdapter());
         tradeTypesRegistry.put(NumismaticOverhaul.id("buy_stack"), new BuyStackAdapter());
+        tradeTypesRegistry.put(NumismaticOverhaul.id("buy_tag"), new BuyTagAdapter());
     }
 
     public static void loadProfession(Identifier fileId, JsonObject jsonRoot) {

--- a/src/main/java/com/glisco/numismaticoverhaul/villagers/json/adapters/BuyTagAdapter.java
+++ b/src/main/java/com/glisco/numismaticoverhaul/villagers/json/adapters/BuyTagAdapter.java
@@ -1,0 +1,78 @@
+package com.glisco.numismaticoverhaul.villagers.json.adapters;
+
+import com.glisco.numismaticoverhaul.NumismaticOverhaul;
+import com.glisco.numismaticoverhaul.currency.Currency;
+import com.glisco.numismaticoverhaul.currency.CurrencyHelper;
+import com.glisco.numismaticoverhaul.villagers.json.TradeJsonAdapter;
+import com.glisco.numismaticoverhaul.villagers.json.VillagerJsonHelper;
+import com.google.gson.JsonObject;
+import io.wispforest.owo.ops.TextOps;
+import net.minecraft.entity.Entity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.tag.TagKey;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.JsonHelper;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.village.TradeOffer;
+import net.minecraft.village.TradeOffers;
+import org.jetbrains.annotations.NotNull;
+
+public class BuyTagAdapter extends TradeJsonAdapter {
+
+    @Override
+    @NotNull
+    public TradeOffers.Factory deserialize(JsonObject json) {
+        loadDefaultStats(json, true);
+
+        VillagerJsonHelper.assertJsonObject(json, "buy");
+
+        final var buyObject = JsonHelper.getObject(json, "buy");
+        final var tag = new Identifier(JsonHelper.getString(buyObject, "tag"));
+        final int count = JsonHelper.getInt(buyObject, "count", 1);
+
+        int price = json.get("price").getAsInt();
+        return new Factory(tag, count, price, max_uses, villager_experience, price_multiplier);
+    }
+
+    private static class Factory implements TradeOffers.Factory {
+        private final Identifier buyTag;
+        private final int count;
+        private final int maxUses;
+        private final int experience;
+        private final int price;
+        private final float multiplier;
+
+        public Factory(Identifier buyTag, int count, int price, int maxUses, int experience, float multiplier) {
+            this.buyTag = buyTag;
+            this.count = count;
+            this.maxUses = maxUses;
+            this.experience = experience;
+            this.price = price;
+            this.multiplier = multiplier;
+        }
+
+        public TradeOffer create(Entity entity, Random random) {
+            final var entries = Registries.ITEM.getEntryList(TagKey.of(RegistryKeys.ITEM, buyTag))
+                    .orElse(null);
+
+            if (entries == null) {
+                NumismaticOverhaul.LOGGER.warn("Could not generate trade for tag '" + buyTag + "', as it does not exist");
+
+                final var player = entity.getWorld().getClosestPlayer(entity, 15);
+                if (player != null) {
+                    player.sendMessage(TextOps.withColor("numismatic §> there has been a problem generating trades, check the log for details",
+                            Currency.GOLD.getNameColor(), TextOps.color(Formatting.GRAY)), false);
+                }
+
+                return null;
+            }
+
+            final var buyStack = new ItemStack(entries.get(random.nextInt(entries.size())).value(), this.count);
+            return new TradeOffer(CurrencyHelper.getClosest(price), buyStack, this.maxUses, this.experience, multiplier);
+        }
+    }
+
+}


### PR DESCRIPTION
As discussed in https://github.com/wisp-forest/numismatic-overhaul/issues/150#issue-2618063972 buy_tag functionality has been added.

This is mostly for testing reasons.
All code is derived from existing the Sell_Tag handler.

Tested based on latest available 1.20.1 build 0.2.12