### PR TITLE
Prevent extracting below 0 or more than player amount

### DIFF
--- a/src/main/java/com/glisco/numismaticoverhaul/network/RequestPurseActionC2SPacket.java
+++ b/src/main/java/com/glisco/numismaticoverhaul/network/RequestPurseActionC2SPacket.java
@@ -15,11 +15,12 @@ public record RequestPurseActionC2SPacket(Action action, long value) {
             case STORE_ALL ->
                     ModComponents.CURRENCY.get(player).modify(CurrencyHelper.getMoneyInInventory(player, true));
             case EXTRACT -> {
-                //Check if we can actually extract this much money to prevent cheeky packet forgery
-                if (ModComponents.CURRENCY.get(player).getValue() < value) return;
+                //Limit the amount of money we cam extract to prevent cheeky packet forgery
+                //It'd be a bit of a problem if a player somehow tried to extract -200 ;)
+                var extracting = Math.max(0, Math.min(value, ModComponents.CURRENCY.get(player).getValue()))
 
-                CurrencyConverter.getAsItemStackList(value).forEach(stack -> player.getInventory().offerOrDrop(stack));
-                ModComponents.CURRENCY.get(player).modify(-value);
+                CurrencyConverter.getAsItemStackList(extracting).forEach(stack -> player.getInventory().offerOrDrop(stack));
+                ModComponents.CURRENCY.get(player).modify(-extracting);
             }
             case EXTRACT_ALL -> {
                 CurrencyConverter.getAsValidStacks(ModComponents.CURRENCY.get(player).getValue())


### PR DESCRIPTION
You did (kinda) correctly stop cheeky packet forgery... but it returns nothing if amount is over the player's balance and didn't check for negatives! New changes are as follows:
- Limit the extracting amount from 0 to playerBalance
  - Now, if cheeky packet forgery occurs, and amount is over playerBalance, it'll extract the whole player's balance as if you requested to extract all. This way, it doesn't just exit out and do nothing and it still protects you from extracting more than what is available.
  - Also, to prevent players adding to their balance, I made sure to stop it from going below 0. This file is the only one I've looked at so apologies if maybe this is checked somewhere else.

I have no idea how I stumbled onto this mod - I've never used it yet I was looking at the code and found this bug lol.