### PR TITLE
New trade adapters: sell_enchanted_item and buy_tag

### DIFF
--- a/src/main/java/com/glisco/numismaticoverhaul/villagers/json/VillagerTradesHandler.java
+++ b/src/main/java/com/glisco/numismaticoverhaul/villagers/json/VillagerTradesHandler.java
@@ -49,12 +49,14 @@ public class VillagerTradesHandler {
         tradeTypesRegistry.put(NumismaticOverhaul.id("dimension_sell_stack"), new DimensionAwareSellStackAdapter());
         tradeTypesRegistry.put(NumismaticOverhaul.id("sell_map"), new SellMapAdapter());
         tradeTypesRegistry.put(NumismaticOverhaul.id("sell_single_enchantment"), new SellSingleEnchantmentAdapter());
+        tradeTypesRegistry.put(NumismaticOverhaul.id("sell_enchanted_item"), new SellEnchantedItemAdapter());
         tradeTypesRegistry.put(NumismaticOverhaul.id("enchant_item"), new EnchantItemAdapter());
         tradeTypesRegistry.put(NumismaticOverhaul.id("process_item"), new ProcessItemAdapter());
         tradeTypesRegistry.put(NumismaticOverhaul.id("sell_dyed_armor"), new SellDyedArmorAdapter());
         tradeTypesRegistry.put(NumismaticOverhaul.id("sell_potion_container"), new SellPotionContainerItemAdapter());
         tradeTypesRegistry.put(NumismaticOverhaul.id("buy_item"), new BuyStackAdapter());
         tradeTypesRegistry.put(NumismaticOverhaul.id("buy_stack"), new BuyStackAdapter());
+        tradeTypesRegistry.put(NumismaticOverhaul.id("buy_tag"), new BuyTagAdapter());
     }
 
     public static void loadProfession(Identifier fileId, JsonObject jsonRoot) {

--- a/src/main/java/com/glisco/numismaticoverhaul/villagers/json/adapters/BuyTagAdapter.java
+++ b/src/main/java/com/glisco/numismaticoverhaul/villagers/json/adapters/BuyTagAdapter.java
@@ -1,0 +1,81 @@
+package com.glisco.numismaticoverhaul.villagers.json.adapters;
+
+import com.glisco.numismaticoverhaul.NumismaticOverhaul;
+import com.glisco.numismaticoverhaul.currency.Currency;
+import com.glisco.numismaticoverhaul.currency.CurrencyHelper;
+import com.glisco.numismaticoverhaul.villagers.json.TradeJsonAdapter;
+import com.glisco.numismaticoverhaul.villagers.json.VillagerJsonHelper;
+import com.google.gson.JsonObject;
+import io.wispforest.owo.ops.TextOps;
+import net.minecraft.entity.Entity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.tag.TagKey;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.JsonHelper;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.village.TradeOffer;
+import net.minecraft.village.TradeOffers;
+import org.jetbrains.annotations.NotNull;
+
+public class BuyTagAdapter extends TradeJsonAdapter {
+
+    @Override
+    @NotNull
+    public TradeOffers.Factory deserialize(JsonObject json) {
+        loadDefaultStats(json, true);
+
+        VillagerJsonHelper.assertJsonObject(json, "buy");
+
+        final var buyObject = JsonHelper.getObject(json, "buy");
+        final var tag = new Identifier(JsonHelper.getString(buyObject, "tag"));
+        final int count = JsonHelper.getInt(buyObject, "count", 1);
+
+        int price = json.get("price").getAsInt();
+        return new Factory(tag, count, price, max_uses, villager_experience, price_multiplier);
+    }
+
+    private static class Factory implements TradeOffers.Factory {
+        private final Identifier buyTag;
+        private final int price;
+        private final int maxUses;
+        private final int experience;
+        private final float multiplier;
+        private final int count;
+
+        public Factory(Identifier buyTag, int count, int price, int maxUses, int experience, float multiplier) {
+            this.buyTag = buyTag;
+            this.count = count;
+            this.maxUses = maxUses;
+            this.experience = experience;
+            this.price = price;
+            this.multiplier = multiplier;
+        }
+
+        public TradeOffer create(Entity entity, Random random) {
+            final var entries = Registries.ITEM.getEntryList(TagKey.of(RegistryKeys.ITEM, buyTag))
+                    .orElse(null);
+
+            if (entries == null) {
+                NumismaticOverhaul.LOGGER.warn("Could not generate trade for tag '" + buyTag + "', as it does not exist");
+
+                final var player = entity.getWorld().getClosestPlayer(entity, 15);
+                if (player != null) {
+                    player.sendMessage(TextOps.withColor("numismatic §> there has been a problem generating trades, check the log for details",
+                            Currency.GOLD.getNameColor(), TextOps.color(Formatting.GRAY)), false);
+                }
+
+                return null;
+            }
+            int randomPrice = price;
+            randomPrice += randomPrice * 0.10f * MathHelper.nextFloat(random, 0.4f, 2.0f);
+
+            final var buyStack = new ItemStack(entries.get(random.nextInt(entries.size())).value(), this.count);
+            return new TradeOffer(buyStack, CurrencyHelper.getClosest(randomPrice), this.maxUses, this.experience, multiplier);
+        }
+    }
+
+}

--- a/src/main/java/com/glisco/numismaticoverhaul/villagers/json/adapters/SellEnchantedItemAdapter.java
+++ b/src/main/java/com/glisco/numismaticoverhaul/villagers/json/adapters/SellEnchantedItemAdapter.java
@@ -1,0 +1,72 @@
+package com.glisco.numismaticoverhaul.villagers.json.adapters;
+
+import com.glisco.numismaticoverhaul.currency.CurrencyHelper;
+import com.glisco.numismaticoverhaul.villagers.json.TradeJsonAdapter;
+import com.glisco.numismaticoverhaul.villagers.json.VillagerJsonHelper;
+import com.google.gson.JsonObject;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.Entity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.util.JsonHelper;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.village.TradeOffer;
+import net.minecraft.village.TradeOffers;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
+public class SellEnchantedItemAdapter extends TradeJsonAdapter {
+
+    @Override
+    @NotNull
+    public TradeOffers.Factory deserialize(JsonObject json) {
+
+        loadDefaultStats(json, false);
+        VillagerJsonHelper.assertInt(json, "level");
+
+        boolean allow_treasure = VillagerJsonHelper.boolean_getOrDefault(json, "allow_treasure", false);
+
+        int level = json.get("level").getAsInt();
+        ItemStack itemToEnchant = VillagerJsonHelper.ItemStack_getOrDefault(json, "item", new ItemStack(Items.BOOK));
+        int base_price = JsonHelper.getInt(json, "base_price", 200);
+
+        return new Factory(itemToEnchant, max_uses, villager_experience, level, allow_treasure, price_multiplier, base_price);
+    }
+
+    private static class Factory implements TradeOffers.Factory {
+        private final int experience;
+        private final int maxUses;
+        private final int level;
+        private final boolean allowTreasure;
+        private final ItemStack itemToEnchant;
+        private final float multiplier;
+        private final int basePrice;
+
+        public Factory(ItemStack item, int maxUses, int experience, int level, boolean allowTreasure, float multiplier, int basePrice) {
+            this.experience = experience;
+            this.maxUses = maxUses;
+            this.level = level;
+            this.allowTreasure = allowTreasure;
+            this.itemToEnchant = item;
+            this.multiplier = multiplier;
+            this.basePrice = basePrice;
+        }
+
+        public TradeOffer create(Entity entity, Random random) {
+            ItemStack itemStack = itemToEnchant.copy();
+            itemStack = EnchantmentHelper.enchant(random, itemStack, level, allowTreasure);
+
+            int price = basePrice;
+            for (Map.Entry<Enchantment, Integer> entry : EnchantmentHelper.get(itemStack).entrySet()) {
+                price += price * 0.10f + basePrice * (entry.getKey().isTreasure() ? 2f : 1f) *
+                        entry.getValue() * MathHelper.nextFloat(random, .8f, 1.2f)
+                        * (5f / (float) entry.getKey().getRarity().getWeight());
+            }
+
+            return new TradeOffer(CurrencyHelper.getClosest(price), itemStack, maxUses, this.experience, multiplier);
+        }
+    }
+}


### PR DESCRIPTION
regarding https://github.com/wisp-forest/numismatic-overhaul/issues/150
villagers can now buy items based on tags with slightly randomized prices
& villagers can now sell enchanted items without needing the base item to enchant it.

To consider:
buy_tag as of now simply offers a slight price variation per item. This is opinionated and could be debated.